### PR TITLE
Proposal to change catppuccin color to improve telescope search readability

### DIFF
--- a/lua/themes/catppuccin-base16.lua
+++ b/lua/themes/catppuccin-base16.lua
@@ -11,7 +11,7 @@ return {
    base09 ="89DCEB",
    base0A ="F8BD96",
    base0B ="ABE9B3",
-   base0C ="D9E0EE",
+   base0C ="F5C2E7",
    base0D ="96CDFB",
    base0E ="F28FAD",
    base0F ="E8A2AF",


### PR DESCRIPTION
It is very hard to see the highlighted part of the search in telescope when using the catppuccin theme. 
This PR aims to fix that by replacing white with pink for base0C color.

Before:
<img width="1645" alt="Screenshot 2022-04-13 at 14 08 27" src="https://user-images.githubusercontent.com/3298487/163173193-d59703f0-30c5-4e0d-8a2a-1e6cb4d64213.png">

After:
<img width="1645" alt="Screenshot 2022-04-13 at 14 07 22" src="https://user-images.githubusercontent.com/3298487/163173235-5ff0dccb-3293-44c4-bf12-cbeb06f9efe8.png">

